### PR TITLE
Add Client and Seller entities with configurations

### DIFF
--- a/SnapSell.Model/Models/SqlEntities/Client.cs
+++ b/SnapSell.Model/Models/SqlEntities/Client.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SnapSell.Domain.Models.SqlEntities
+﻿namespace SnapSell.Domain.Models.SqlEntities
 {
     public class Client
     {

--- a/SnapSell.Model/Models/SqlEntities/Seller.cs
+++ b/SnapSell.Model/Models/SqlEntities/Seller.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SnapSell.Domain.Models.SqlEntities
+{
+    public class Seller
+    {
+        public string Id { get; set; }
+        public virtual Account Account { get; set; }
+    }
+}

--- a/SnapSell.Model/Models/SqlEntities/Store.cs
+++ b/SnapSell.Model/Models/SqlEntities/Store.cs
@@ -4,8 +4,8 @@ namespace SnapSell.Domain.Models.SqlEntities
 {
     public class Store
     {
-        public string Id { get; set; }
-        public virtual Account Account { get; set; }
+        public Guid SellerId { get; set; }
+        public Seller Seller { get; set; } 
         public string Name { get; set; }
         public string Description { get; set; }
         public int MinimumDeliverPeriod { get; set; }

--- a/SnapSell.Presentation/EndPoints/ProductController.cs
+++ b/SnapSell.Presentation/EndPoints/ProductController.cs
@@ -33,7 +33,7 @@ public sealed class ProductController(ISender sender) : ApiControllerBase
     }
 
     [HttpGet("GetAllSizes")]
-    public async Task<ActionResult<Result<IReadOnlyList<GetAllSizesResponse>>>> GetAllSizess(CancellationToken cancellationToken)
+    public async Task<ActionResult<Result<IReadOnlyList<GetAllSizesResponse>>>> GetAllSizes(CancellationToken cancellationToken)
     {
         var query = new GetAllSizesQuery();
         var result = await sender.Send(query, cancellationToken);

--- a/SnapSell.Presistance/Context/SqlDbContext.cs
+++ b/SnapSell.Presistance/Context/SqlDbContext.cs
@@ -19,7 +19,8 @@ public sealed class SqlDbContext(DbContextOptions<SqlDbContext> options, IHttpCo
     public DbSet<OrderAddress> OrderAddresses { get; set; }
     public DbSet<ShoppingBag> ShoppingBags { get; set; }
     public DbSet<Review> Reviews { get; set; }
-
+    public DbSet<Seller> Sellers { get; set; }
+    public DbSet<Client> Clients { get; set; }
     public DbSet<Size> Sizes { get; set; }
 
     //public DbSet<CacheCode> CacheCodes { get; set; }

--- a/SnapSell.Presistance/EntityConfiguration/SellerConfiguration.cs
+++ b/SnapSell.Presistance/EntityConfiguration/SellerConfiguration.cs
@@ -4,13 +4,13 @@ using SnapSell.Domain.Models.SqlEntities;
 
 namespace SnapSell.Presistance.EntityConfiguration
 {
-    public class ClientConfiguration : IEntityTypeConfiguration<Client>
+    internal class SellerConfiguration : IEntityTypeConfiguration<Seller>
     {
-        public void Configure(EntityTypeBuilder<Client> builder)
+        public void Configure(EntityTypeBuilder<Seller> builder)
         {
             builder.HasOne(x => x.Account)
                 .WithOne()
-                .HasForeignKey<Client>(x => x.Id);
+                .HasForeignKey<Seller>(x => x.Id);
         }
     }
 }


### PR DESCRIPTION
- Defined `Client` and `Seller` classes in the `SqlEntities` namespace.
- Updated `Store` class to include `SellerId` and `Seller` properties.
- Corrected method name from `GetAllSizess` to `GetAllSizes` in `ProductController`.
- Added `DbSet` properties for `Sellers` and `Clients` in `SqlDbContext`.
- Retained configuration for `Client` and added configuration for `Seller`.