### PR TITLE
Add email OTP functionality and localization updates

### DIFF
--- a/SnapSell.API/Resources/ar.json
+++ b/SnapSell.API/Resources/ar.json
@@ -1,5 +1,7 @@
 ﻿{
   "Welcome": "مرحبًا بك في SnapSell",
   "StoreNotFound": "المتجر غير موجود.",
-  "BrandIdIsRequired" : ""
+  "BrandIdIsRequired": "",
+  "EmailOtpSent": "تم إرسال رمز التحقق إلى بريدك الإلكتروني.",
+  "InvalidOtp": "رمز التحقق غير صالح. يرجى المحاولة مرة أخرى."
 }

--- a/SnapSell.API/Resources/en.json
+++ b/SnapSell.API/Resources/en.json
@@ -1,5 +1,7 @@
 {
   "Welcome": "Welcome to SnapSell",
   "StoreNotFound": "Store not found.",
-  "BrandIdIsRequired": "BrandId is required"
+  "BrandIdIsRequired": "BrandId is required",
+  "EmailOtpSent": "An OTP has been sent to your email address.",
+  "InvalidOtp": "Invalid OTP. Please try again."
 }

--- a/SnapSell.API/appsettings.Development.json
+++ b/SnapSell.API/appsettings.Development.json
@@ -5,7 +5,7 @@
   },
   "Jwt": {
     "Issuer": "SnapSell",
-    "Audience": "snapSell",
+    "Audience": "snapSell@gmail.com",
     "SecureKey": "EdMLGsCZCpgAcvZ5IYgoa5QMkiK7+RTf95hApqI8oI4=",
     "ExpireInDays": 30,
     "MobileExpireInDays": 365

--- a/SnapSell.API/appsettings.json
+++ b/SnapSell.API/appsettings.json
@@ -19,5 +19,8 @@
     "EnableSSL": true,
     "UseDefaultCredentials": false
   },
+  "Emails": {
+    "EmailConfirmation": "\\EmailTemplates\\ConfirmationEmail.html"
+  }
   "AllowedHosts": "*"
 }

--- a/SnapSell.API/wwwroot/EmailTemplates/ConfirmationEmail.html
+++ b/SnapSell.API/wwwroot/EmailTemplates/ConfirmationEmail.html
@@ -1,0 +1,91 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style type="text/css">
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333333;
+            margin: 0;
+            padding: 0;
+            background-color: #f5f5f5;
+        }
+
+        .email-container {
+            max-width: 500px;
+            margin: 20px auto;
+            padding: 20px;
+            background-color: #ffffff;
+            border-radius: 5px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
+
+        .header {
+            text-align: center;
+            padding-bottom: 20px;
+            border-bottom: 1px solid #eeeeee;
+        }
+
+        .content {
+            padding: 20px 0;
+            text-align: center;
+        }
+
+        .otp-box {
+            background-color: #f8f9fa;
+            border: 2px dashed #cccccc;
+            padding: 15px;
+            margin: 25px auto;
+            border-radius: 5px;
+            display: inline-block;
+        }
+
+        .otp-code {
+            font-size: 32px;
+            font-weight: bold;
+            letter-spacing: 5px;
+            color: #e74c3c;
+        }
+
+        .message {
+            font-size: 16px;
+            margin-bottom: 20px;
+        }
+
+        .footer {
+            text-align: center;
+            padding-top: 20px;
+            font-size: 12px;
+            color: #777777;
+            border-top: 1px solid #eeeeee;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="header">
+            <h2>Verification Code</h2>
+        </div>
+
+        <div class="content">
+            <div class="message">
+                <p>Please use the following code to confirm your action:</p>
+            </div>
+
+            <div class="otp-box">
+                <div class="otp-code">@Model.OTP</div>
+            </div>
+
+            <div class="message">
+                <p>This code will expire in 5 minutes.</p>
+                <p>Do not share this code with anyone.</p>
+            </div>
+        </div>
+
+        <div class="footer">
+            <p>If you didn't request this code, please ignore this email.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/SnapSell.Application/Features/Authentication/Commands/ConfirmEmailOtpCommand/ConfirmEmailOtpCommand.cs
+++ b/SnapSell.Application/Features/Authentication/Commands/ConfirmEmailOtpCommand/ConfirmEmailOtpCommand.cs
@@ -1,0 +1,30 @@
+﻿using MediatR;
+using SnapSell.Domain.Dtos.ResultDtos;
+using SnapSell.Domain.Enums;
+
+namespace SnapSell.Application.Features.Authentication.Commands.ConfirmEmailOtpCommand
+{
+    public record ConfirmEmailOtpCommand(
+        string Email,
+        string Otp) : IRequest<Result<ConfirmEmailOtpCommandResponse>>;
+
+    public class ConfirmEmailOtpCommandResponse
+    {
+        public ConfirmOtpStoreInfoDto? Store { get; set; }
+        public List<string> Roles { get; set; }
+        public string UserName { get; set; }
+        public string FullName { get; set; }
+    }
+
+    public class ConfirmOtpStoreInfoDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public int MinimumDeliverPeriod { get; set; }
+        public int MaximumDeliverPeriod { get; set; }
+        public StoreStatusTypes Status { get; set; }
+        public virtual DeliverPeriodTypes DeliverPeriodTypes { get; set; }
+        public string? LogoUrl { get; set; }
+    }
+}

--- a/SnapSell.Application/Features/Authentication/Commands/ConfirmEmailOtpCommand/ConfirmEmailOtpCommandHandler.cs
+++ b/SnapSell.Application/Features/Authentication/Commands/ConfirmEmailOtpCommand/ConfirmEmailOtpCommandHandler.cs
@@ -1,0 +1,66 @@
+﻿using Mapster;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Localization;
+using SnapSell.Application.Interfaces;
+using SnapSell.Domain.Dtos.ResultDtos;
+using SnapSell.Domain.Models.SqlEntities;
+
+namespace SnapSell.Application.Features.Authentication.Commands.ConfirmEmailOtpCommand
+{
+    internal class ConfirmEmailOtpCommandHandler : IRequestHandler<ConfirmEmailOtpCommand, Result<ConfirmEmailOtpCommandResponse>>
+    {
+        private readonly UserManager<Account> _userManager;
+        private readonly IMemoryCache _memoryCache;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IStringLocalizer<ConfirmEmailOtpCommandHandler> _localizer;
+
+        public ConfirmEmailOtpCommandHandler(
+            UserManager<Account> userManager,
+            IMemoryCache memoryCache,
+            IUnitOfWork unitOfWork,
+            IStringLocalizer<ConfirmEmailOtpCommandHandler> localizer)
+        {
+            _userManager = userManager;
+            _memoryCache = memoryCache;
+            _unitOfWork = unitOfWork;
+            _localizer = localizer;
+        }
+
+        public async Task<Result<ConfirmEmailOtpCommandResponse>> Handle(ConfirmEmailOtpCommand request, CancellationToken cancellationToken)
+        {
+            var otp = _memoryCache.Get<string>("ConfirmEmail" + request.Email);
+
+            if (otp is null || otp != request.Otp)
+            {
+                return Result<ConfirmEmailOtpCommandResponse>.Failure(_localizer["InvalidOtp"]);
+            }
+
+            _memoryCache.Remove("ConfirmEmail" + request.Email);
+
+            var user = await _userManager.FindByEmailAsync(request.Email);
+
+            if (user is null)
+            {
+                return Result<ConfirmEmailOtpCommandResponse>.Success();
+            }
+
+            var roles = await _userManager.GetRolesAsync(user);
+
+            var store = await _unitOfWork.StoresRepo.Entities
+                .Where(x => x.SellerId.ToString() == user.Id)
+                .ProjectToType<ConfirmOtpStoreInfoDto>()
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return Result<ConfirmEmailOtpCommandResponse>.Success(new ConfirmEmailOtpCommandResponse()
+            {
+                FullName = user.FullName,
+                UserName = user.UserName!,
+                Roles = roles.ToList(),
+                Store = store
+            });
+        }
+    }
+}

--- a/SnapSell.Application/Features/Authentication/Commands/RegisterSeller/RegisterSellerCommandHandler.cs
+++ b/SnapSell.Application/Features/Authentication/Commands/RegisterSeller/RegisterSellerCommandHandler.cs
@@ -35,7 +35,7 @@ internal sealed class RegisterSellerCommandHandler(
         if (!result.Succeeded)
         {
             return Result<RegisterSellerResult>.Failure(
-                message: "Creation Of user proess is failed",
+                message: "Creation Of user process is failed",
                 statusCode: HttpStatusCode.BadRequest);
         }
 

--- a/SnapSell.Application/Features/Authentication/Commands/SendConfirmationEmailOtp/SendConfirmationEmailOtpCommand.cs
+++ b/SnapSell.Application/Features/Authentication/Commands/SendConfirmationEmailOtp/SendConfirmationEmailOtpCommand.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using SnapSell.Domain.Dtos.ResultDtos;
+
+namespace SnapSell.Application.Features.Authentication.Commands.SendConfirmationEmailOtp
+{
+    public sealed record SendConfirmationEmailOtpCommand(
+        string Email
+        ) : IRequest<Result<string>>;
+}

--- a/SnapSell.Application/Features/Authentication/Commands/SendConfirmationEmailOtp/SendConfirmationEmailOtpCommandHandler.cs
+++ b/SnapSell.Application/Features/Authentication/Commands/SendConfirmationEmailOtp/SendConfirmationEmailOtpCommandHandler.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Localization;
+using SnapSell.Domain.Dtos.ResultDtos;
+
+namespace SnapSell.Application.Features.Authentication.Commands.SendConfirmationEmailOtp
+{
+    internal class SendConfirmationEmailOtpCommandHandler(
+        IMemoryCache memoryCache,
+        IStringLocalizer<SendConfirmationEmailOtpCommandHandler> localizer) : IRequestHandler<SendConfirmationEmailOtpCommand, Result<string>>
+    {
+        private readonly IMemoryCache _memoryCache = memoryCache;
+        private readonly IStringLocalizer<SendConfirmationEmailOtpCommandHandler> _localizer = localizer;
+
+        public async Task<Result<string>> Handle(SendConfirmationEmailOtpCommand command, CancellationToken cancellationToken)
+        {
+            _memoryCache.Remove("ConfirmEmail" + command.Email);
+
+            var otp = new Random().Next(10000, 99999).ToString();
+
+            _memoryCache.Set("ConfirmEmail" + command.Email, otp, TimeSpan.FromMinutes(5));
+
+            return Result<string>.Success(data: otp, _localizer["EmailOtpSent"]);
+        }
+    }
+}

--- a/SnapSell.Application/Features/Authentication/Commands/SendConfirmationEmailOtp/SendConfirmationEmailOtpCommandValidator.cs
+++ b/SnapSell.Application/Features/Authentication/Commands/SendConfirmationEmailOtp/SendConfirmationEmailOtpCommandValidator.cs
@@ -1,0 +1,19 @@
+﻿using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SnapSell.Application.Features.Authentication.Commands.SendConfirmationEmailOtp
+{
+    public class SendConfirmationEmailOtpCommandValidator:AbstractValidator<SendConfirmationEmailOtpCommand>
+    {
+        public SendConfirmationEmailOtpCommandValidator()
+        {
+            RuleFor(x => x.Email)
+                .NotEmpty().WithMessage("Email is required.")
+                .EmailAddress().WithMessage("Invalid email format.");
+        }
+    }
+}

--- a/SnapSell.Application/Interfaces/IEmailService.cs
+++ b/SnapSell.Application/Interfaces/IEmailService.cs
@@ -8,5 +8,6 @@ namespace SnapSell.Application.Interfaces
 {
     public interface IEmailService
     {
+        public Task<bool> SendEmailConfirmationOtp(string email, string otp);
     }
 }

--- a/SnapSell.Infrastructure/Services/MailServices/EmailSender.cs
+++ b/SnapSell.Infrastructure/Services/MailServices/EmailSender.cs
@@ -19,7 +19,7 @@ namespace SnapSell.Infrastructure.Services.MailServices
             {
                 var sendResponse = await _fluentEmail
                                         .Create()
-                                        .SetFrom(request.From, "PSolve")
+                                        .SetFrom(request.From, "SnapSell")
                                         .To(request.To)
                                         .Subject(request.Subject)
                                         .UsingTemplate(request.Body, request.BodyData)

--- a/SnapSell.Infrastructure/Services/MailServices/EmailService.cs
+++ b/SnapSell.Infrastructure/Services/MailServices/EmailService.cs
@@ -1,4 +1,7 @@
-﻿using SnapSell.Application.Interfaces;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using SnapSell.Application.Interfaces;
+using SnapSell.Domain.Dtos.MailDtos;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +10,33 @@ using System.Threading.Tasks;
 
 namespace SnapSell.Infrastructure.Services.MailServices
 {
-    public class EmailService:IEmailService
+    public class EmailService : IEmailService
     {
+        private readonly IEmailSender _emailSender;
+        private readonly IConfiguration _filePath;
+        private readonly IWebHostEnvironment _host;
+        private readonly string _email;
+
+        public EmailService(IConfiguration config, IEmailSender emailSender, IWebHostEnvironment webHostEnvironment)
+        {
+            _emailSender = emailSender;
+            _host = webHostEnvironment;
+            _filePath = config.GetSection("EmailTemplates");
+            _email = config.GetSection("Jwt:Audience").Value!;
+        }
+
+        public async Task<bool> SendEmailConfirmationOtp(string email, string otp)
+        {
+            var content = File.ReadAllText(_host.WebRootPath + _filePath["EmailConfirmationTemplate"]);
+
+            return await _emailSender.SendMailUsingRazorTemplateAsync(new EmailRequestDto
+            {
+                Body = content,
+                BodyData = new { OTP = otp },
+                From = _email,
+                Subject = "SnapSell Email Confirmation",
+                To = email
+            });
+        }
     }
 }

--- a/SnapSell.Model/Models/SqlEntities/Store.cs
+++ b/SnapSell.Model/Models/SqlEntities/Store.cs
@@ -2,10 +2,10 @@
 
 namespace SnapSell.Domain.Models.SqlEntities
 {
-    public class Store
+    public class Store : BaseEntity
     {
         public Guid SellerId { get; set; }
-        public Seller Seller { get; set; } 
+        public Seller Seller { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
         public int MinimumDeliverPeriod { get; set; }

--- a/SnapSell.Presentation/EndPoints/AccountController.cs
+++ b/SnapSell.Presentation/EndPoints/AccountController.cs
@@ -1,7 +1,9 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using SnapSell.Application.Features.Authentication.Commands.ConfirmEmailOtpCommand;
 using SnapSell.Application.Features.Authentication.Commands.RegisterCustomer;
 using SnapSell.Application.Features.Authentication.Commands.RegisterSeller;
+using SnapSell.Application.Features.Authentication.Commands.SendConfirmationEmailOtp;
 using SnapSell.Application.Features.Authentication.Queries.CustomerLogIn;
 using SnapSell.Application.Features.Authentication.Queries.SellerLogin;
 using SnapSell.Domain.Dtos.ResultDtos;
@@ -41,4 +43,21 @@ public sealed class AccountController(ISender sender) : ApiControllerBase
         var result = await sender.Send(query, cancellationToken);
         return await HandleMediatorResult(result);
     }
+
+    [HttpPost("SendEmailConfirmationOtp")]
+    public async Task<ActionResult<Result<string>>> SendEmailConfirmationOtp(SendConfirmationEmailOtpCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+        return await HandleMediatorResult(result);
+    }
+
+    [HttpPost("ConfirmEmail")]
+    public async Task<ActionResult<Result<ConfirmEmailOtpCommandResponse>>>ConfirmEmail(ConfirmEmailOtpCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+        return await HandleMediatorResult(result);
+    }
+
 }


### PR DESCRIPTION
- Updated localization files for email OTP messages.
- Modified JWT audience in appsettings for development.
- Added new "Emails" section in appsettings for email templates.
- Corrected typo in RegisterSellerCommandHandler error message.
- Enhanced IEmailService with method for sending email OTPs.
- Changed sender name in EmailSender to "SnapSell".
- Refactored EmailService to support email OTP functionality.
- Ensured proper inheritance in Store model.
- Updated AccountController with new endpoints for email OTP.
- Added HTML template for email confirmation.
- Created new command and handler classes for email OTP.
- Implemented validation for email OTP command.