### PR TITLE
Remove MainVideoUrl from product query and handler

### DIFF
--- a/SnapSell.Application/Features/Products/Queries/GetProductById/GetProductByIdQuery.cs
+++ b/SnapSell.Application/Features/Products/Queries/GetProductById/GetProductByIdQuery.cs
@@ -25,7 +25,6 @@ namespace SnapSell.Application.Features.Products.Queries.GetProductById
         public int MinDeliveryDays { get; set; }
         public int MaxDeliveryDays { get; set; }
         public List<string> ImagesUrl { get; set; }
-        public string? MainVideoUrl { get; set; }
         [JsonIgnore]
         public Guid BrandId { get; set; }
         public string BrandName { get; set; }

--- a/SnapSell.Application/Features/Products/Queries/GetProductById/GetProductByIdQueryHandler.cs
+++ b/SnapSell.Application/Features/Products/Queries/GetProductById/GetProductByIdQueryHandler.cs
@@ -36,7 +36,6 @@ namespace SnapSell.Application.Features.Products.Queries.GetProductById
                     ImagesUrl = x.Images.OrderByDescending(x => x.IsMainImage).Select(x => x.ImageUrl).ToList(),
                     MaxDeliveryDays = x.MaxDeliveryDays,
                     MinDeliveryDays = x.MinDeliveryDays,
-                    MainVideoUrl = x.MainVideoUrl,
                     BrandId = x.BrandId,
                     ProductType = x.ProductType,
                     ShippingType = x.ShippingType,


### PR DESCRIPTION
The `MainVideoUrl` property has been removed from the `GetProductByIdQuery` class, indicating it is no longer part of the product query data structure. The corresponding assignment in `GetProductByIdQueryHandler` has also been eliminated, meaning the handler will no longer retrieve or process the main video URL when fetching product details.