### PR TITLE
Add Video property to ProductVideo class

### DIFF
--- a/SnapSell.Model/Models/SqlEntities/ProductVideo.cs
+++ b/SnapSell.Model/Models/SqlEntities/ProductVideo.cs
@@ -13,5 +13,6 @@ namespace SnapSell.Domain.Models.SqlEntities
         public virtual Product Product { get; set; }
         public Guid VideoId { get; set; }
         public virtual Video Video { get; set; }
+
     }
 }


### PR DESCRIPTION
Introduced a new `Video` property of type `virtual Video` in the `ProductVideo` class within the
`SnapSell.Domain.Models.SqlEntities` namespace. This property is linked to the existing `VideoId` property, which serves as a unique identifier for videos.